### PR TITLE
Add a prompt to create new named zettels

### DIFF
--- a/lua/neuron/cmd.lua
+++ b/lua/neuron/cmd.lua
@@ -99,6 +99,25 @@ function M.new_edit(neuron_dir)
   }:start()
 end
 
+function M.new_edit_named(neuron_dir, name)
+  Job:new {
+    command = "neuron",
+    args = {"new", name},
+    cwd = neuron_dir,
+    --on_stderr = utils.on_stderr_factory("neuron new " .. name),
+    interactive = false,
+    on_stdout = vim.schedule_wrap(
+      function(error, data)
+        assert(not error, error)
+
+        vim.cmd("edit " .. data)
+        utils.start_insert_header()
+      end
+    ),
+    on_exit = utils.on_exit_factory("neuron new " .. name)
+  }:start()
+end
+
 function M.new_and_callback(neuron_dir, callback)
   Job:new {
     command = "neuron",

--- a/lua/neuron/prompt.lua
+++ b/lua/neuron/prompt.lua
@@ -1,0 +1,70 @@
+local popup = require('popup')
+local config = require('neuron.config')
+local cmd = require('neuron.cmd')
+local utils = require('neuron.utils')
+local a = vim.api
+
+local neuron_prompt_prefix_ns = a.nvim_create_namespace("neuron_prompt_prefix")
+
+local M = {}
+
+function M.prompt_callback(text_inserted)
+  vim.cmd [[stopinsert]]
+  vim.cmd [[quit!]]
+
+  if text_inserted ~= nil and text_inserted ~= "" then
+    local relative_path = utils.get_neuron_path(text_inserted, config.neuron_dir)
+    if vim.fn.filereadable(relative_path) then
+      vim.cmd('edit ' .. relative_path)
+    else
+      cmd.new_edit_named(config.neuron_dir, text_inserted)
+    end
+  end
+end
+
+function M.prompt_new_zettel(opts)
+  local opt_default = opts or {
+    border = {},
+    borderchars = {"─", "│", "─", "│", "╭", "╮", "╯", "╰"},
+    col = 0,
+    line = 0,
+    width = 0,
+    height = 1,
+    enter = true,
+    title = "New Zettel"
+  }
+
+  local cols = a.nvim_get_option('columns')
+  local lines = a.nvim_get_option('lines')
+
+  -- Avoid having float
+  local width = math.floor(cols / 4)
+  local col = math.floor(cols/2 - width/2)
+
+  opt_default.col = col
+  opt_default.width = width
+
+  local line = lines / 2
+  opt_default.line = line
+
+  local prompt_win, prompt_opt = popup.create('', opt_default)
+  local prompt_bufnr = a.nvim_win_get_buf(prompt_win)
+  -- Telescope is required, let's keep a visual consistency by using its highlight
+  a.nvim_win_set_option(prompt_win, 'winhl', 'Normal:TelescopeNormal')
+
+  local prompt_border_win = prompt_opt.border and prompt_opt.border.win_id
+
+  if prompt_border_win then
+    a.nvim_win_set_option(prompt_border_win, 'winhl', 'Normal:TelescopePromptBorder')
+  end
+
+  a.nvim_buf_set_option(prompt_bufnr, 'buftype', 'prompt')
+  a.nvim_buf_set_keymap(prompt_bufnr, 'n', '<Esc>', '<cmd>quit!<cr>', {})
+
+  vim.fn.prompt_setprompt(prompt_bufnr, "> ")
+  vim.fn.prompt_setcallback(prompt_bufnr, M.prompt_callback)
+  a.nvim_buf_add_highlight(prompt_bufnr, neuron_prompt_prefix_ns, 'TelescopePromptPrefix', 0, 0, 2)
+  vim.cmd [[startinsert]]
+end
+
+return M

--- a/lua/neuron/telescope/init.lua
+++ b/lua/neuron/telescope/init.lua
@@ -28,13 +28,13 @@ function M.find_zettels(opts)
 
     if opts.insert then
       picker_opts.attach_mappings = function()
-        actions.goto_file_selection_edit:replace(
+        actions.select_default:replace(
             neuron_actions.insert_maker("id"))
         return true
       end
     else
       picker_opts.attach_mappings = function()
-        actions.goto_file_selection_edit:replace(neuron_actions.edit_or_insert)
+        actions.select_default:replace(neuron_actions.edit_or_insert)
         return true
       end
     end
@@ -64,7 +64,7 @@ function M.find_backlinks(opts)
 
     if opts.insert then
       picker_opts.attach_mappings = function()
-        actions.goto_file_selection_edit:replace(
+        actions.select_default:replace(
             neuron_actions.insert_maker("id"))
         return true
       end
@@ -87,7 +87,7 @@ function M.find_tags(opts)
       previewer = nil,
       sorter = conf.generic_sorter(opts),
       attach_mappings = function()
-        actions.goto_file_selection_edit:replace(
+        actions.select_default:replace(
             neuron_actions.insert_maker("display"))
         return true
       end

--- a/lua/neuron/utils.lua
+++ b/lua/neuron/utils.lua
@@ -103,4 +103,7 @@ function M.start_insert_header()
   M.feedkeys("Go<CR>#<space>", "n")
 end
 
+function M.get_neuron_path(id, neuron_dir)
+  return neuron_dir .. '/' .. id .. '.md'
+end
 return M


### PR DESCRIPTION
This new feature would allow to create new Zettels with names.

The current way with telescope is not enough since the string doesn't have to match 100% for telescope to find a Zettel.

The user can call `require('neuron.prompt').prompt_new_zettel()` to see a small prompt asking for the new id of the file. If it exists it's opened and edited, else it's created and edited.