### PR TITLE
Switch to on_exit callback 

### DIFF
--- a/lua/neuron/cmd.lua
+++ b/lua/neuron/cmd.lua
@@ -10,7 +10,7 @@ function M.neuron(opts)
     args = opts.args,
     cwd = opts.neuron_dir,
     on_stderr = utils.on_stderr_factory(opts.name or "cmd.neuron"),
-    on_stdout = vim.schedule_wrap(M.json_stdout_wrap(opts.callback)),
+    on_exit = vim.schedule_wrap(M.json_stdout_wrap(opts.callback)),
     interactive = false
   }:start()
 end
@@ -73,9 +73,9 @@ end
 
 --- json_fn takes a json table
 function M.json_stdout_wrap(json_fn)
-  return function(error, data)
-    assert(not error, error)
-
+  return function(job, return_val)
+    assert(return_val==0, "Job returned non zero")
+    local data = table.concat(job:result())
     json_fn(vim.fn.json_decode(data))
   end
 end

--- a/lua/neuron/cmd.lua
+++ b/lua/neuron/cmd.lua
@@ -74,7 +74,7 @@ end
 --- json_fn takes a json table
 function M.json_stdout_wrap(json_fn)
   return function(job, return_val)
-    assert(return_val==0, "neuron query returned non zero")
+    utils.on_exit_return_check("neuron query", return_val)
     local data = table.concat(job:result())
     json_fn(vim.fn.json_decode(data))
   end
@@ -89,9 +89,7 @@ function M.new_edit(neuron_dir)
     interactive = false,
     on_exit = vim.schedule_wrap(
       function(job, return_val)
-        assert(return_val==0, 
-                string.format("Job neuron new exited with a non-zero code: %s", 
-                                return_val))
+        utils.on_exit_return_check("neuron new", return_val)
         local data = table.concat(job:result())
         vim.cmd("edit " .. data)
         utils.start_insert_header()
@@ -108,9 +106,7 @@ function M.new_and_callback(neuron_dir, callback)
     on_stderr = utils.on_stderr_factory("neuron new"),
     on_exit = vim.schedule_wrap(
       function(job, return_val)
-        assert(return_val==0, 
-                string.format("Job neuron new exited with a non-zero code: %s", 
-                                return_val))
+        utils.on_exit_return_check("neuron new", return_val)
         local data = table.concat(job:result())
 
         callback(data)

--- a/lua/neuron/utils.lua
+++ b/lua/neuron/utils.lua
@@ -34,14 +34,10 @@ function M.on_stderr_factory(name)
   )
 end
 
-function M.on_exit_factory(name)
-  return vim.schedule_wrap(
-    function(self, code, _signal)
-      if code ~= 0 then
-        error(string.format("The job %s exited with a non-zero code: %s", name, code))
-      end
-    end
-  )
+function M.on_exit_return_check(name, code)
+  if code ~= 0 then
+    error(string.format("The job %s exited with a non-zero code: %s", name, code))
+  end
 end
 
 function M.feedkeys(string, mode)


### PR DESCRIPTION
The current master of neuron now returns multiline json output for the query command. This breaks the json parsing, which is currently done in the on_stdout callback of the plenary Job, which is run after every line in stdout. To fix this I use the on_exit callback (also minor changes in json_stdout_wrap to account for the different signature in on_exit).
For consistency, the new_edit and new_and_callback also use on_exit.
utils.on_exit_factory is replaced to account for new behavior.

Hope I did not break anything else, as this is my first time working with lua...