### PR TITLE
change insert_marker to insert zettel links in link format

### DIFF
--- a/lua/neuron/telescope/actions.lua
+++ b/lua/neuron/telescope/actions.lua
@@ -11,6 +11,7 @@ function M.insert_maker(key)
     actions.close(prompt_bufnr)
 
     local entry = actions.get_selected_entry()
+    local link = "[[" .. entry[key] .. "]]"
     api.nvim_put({entry[key]}, "c", true, true)
   end
 end

--- a/lua/neuron/telescope/actions.lua
+++ b/lua/neuron/telescope/actions.lua
@@ -12,7 +12,7 @@ function M.insert_maker(key)
 
     local entry = actions.get_selected_entry()
     local link = "[[" .. entry[key] .. "]]"
-    api.nvim_put({entry[key]}, "c", true, true)
+    api.nvim_put({link}, "c", true, true)
   end
 end
 


### PR DESCRIPTION
Hello ! Currently neuron.nvim only inserts the filename of the zettel and users have to manually wrap it in double braces. 
Is this by design ? Hope to hear from you. Awesome project !!