### PR TITLE
Resolve & escape neuron_dir in autocmd path match

### DIFF
--- a/lua/neuron/mappings.lua
+++ b/lua/neuron/mappings.lua
@@ -34,7 +34,9 @@ function M.set_keymaps()
 end
 
 function M.setup()
-  vim.cmd(string.format("au BufRead %s/*.md lua require'neuron/mappings'.set_keymaps()", neuron.config.neuron_dir))
+  local real_dir = vim.loop.fs_realpath(neuron.config.neuron_dir)
+  local escaped_dir = vim.fn.escape(real_dir, ' ')
+  vim.cmd(string.format("au BufRead %s/*.md lua require'neuron/mappings'.set_keymaps()", escaped_dir))
   M.map('i', "<cmd>lua require'neuron'.goto_index()<CR>")
 end
 


### PR DESCRIPTION
This does two things to the `neuron_dir` configuration argument before using it in the autocmd path match for setting up mappings:
1. Resolves the real path; this is necessary if the path given is a link of some kind, as vim autocmds appear to compare against the real path.
2. Escapes the path so it is safe to use a path with spaces in it.

Note: There are plenty of things *other* than spaces that, if present in the path, would break its use here. That said, neovim's documentation on `file-pattern` is lacking, and reading through the source code to try and figure out how they're actually interpreted was a *complete* nightmare, so I've just fixed the one problem I actually had. And hell, the other possible issues are ones people are a lot less likely to run into.