### PR TITLE
Open Zettel via Path element from json cache and fix opening links containing an alt name

### DIFF
--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -1,4 +1,5 @@
 local Job = require("plenary/job")
+local Path = require("plenary/path")
 local uv = vim.loop
 local api = vim.api
 local utils = require("neuron/utils")
@@ -67,7 +68,8 @@ function M.enter_link()
   cmd.query_id(id, config.neuron_dir, function(json)
     if type(json) ~= "userdata" then
       --TODO: validate path.
-      vim.cmd(string.format("edit %s", json.Path))
+      local zettle_path = Path:new(config.neuron_dir):joinpath(json.Path)
+      vim.cmd(string.format("edit %s", zettle_path:normalize()))
     end
   end)
 end

--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -54,9 +54,10 @@ function M.open_from_server()
 end
 
 function M.enter_link()
-  local word = vim.fn.expand("<cWORD>")
+  local line = vim.fn.getline(".")
+  local col = vim.fn.col(".")
 
-  local id = utils.match_link(word)
+  local id = utils.match_link_from_line(line, col)
 
   if id == nil then
     vim.cmd("echo 'There is no link under the cursor'")

--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -65,7 +65,8 @@ function M.enter_link()
 
   cmd.query_id(id, config.neuron_dir, function(json)
     if type(json) ~= "userdata" then
-      vim.cmd(string.format("edit %s/%s.md", config.neuron_dir, json.ID))
+      --TODO: validate path.
+      vim.cmd(string.format("edit %s", json.Path))
     end
   end)
 end

--- a/lua/neuron/utils.lua
+++ b/lua/neuron/utils.lua
@@ -48,8 +48,9 @@ function M.feedraw(s)
   api.nvim_feedkeys(s, "n", false)
 end
 
-local TRIPLE_LINK_RE = "%[%[%[(%w+)%]%]%]"
-local DOUBLE_LINK_RE = "%[%[(%w+)%]%]"
+local ANY_LINK_RE = "%[?%[%[(%w+)[|%w%s]*%]%]%]?"
+local TRIPLE_LINK_RE = "%[%[%[(%w+)[|%w%s]*%]%]%]"
+local DOUBLE_LINK_RE = "%[%[(%w+)[|%w%s]*%]%]"
 
 ---@param s string
 function M.match_link(s)
@@ -58,6 +59,21 @@ end
 
 function M.find_link(s)
   return s:find(TRIPLE_LINK_RE) or s:find(DOUBLE_LINK_RE)
+end
+
+---@param s string
+---@param c integer
+function M.match_link_from_line(s, c)
+  c = c or 1
+  local t = {}
+  for i=1,#s do
+    local start, finish = s:find(ANY_LINK_RE, i)
+    if start ~= nil then
+      if start <= c and finish >= c then
+        return s:match(ANY_LINK_RE, start)
+      end
+    end
+  end
 end
 
 -- deletes a range of extmarks line wise, zero based index

--- a/lua/tests/automated/match_spec.lua
+++ b/lua/tests/automated/match_spec.lua
@@ -21,6 +21,13 @@ describe("link match", function()
     eq("fd", id)
   end)
 
+  it("should deal with alt name", function()
+    local line = "- [[ID1|my alt id 1]] [[ID2|my alt id 2]]  [[fdsk4590]]"
+    local pos = line:find("my alt id 2") + 2
+    local id = utils.match_link_from_line(line, pos)
+    eq("ID2", id)
+  end)
+
   -- it('should be okay with edge cases', function()
   --   local link = '[[fdsk4590]]]'
   --   local id = utils.match_link(link)


### PR DESCRIPTION
Thought I'd propose some quick edits I made to the plugin for opening zettel links with alt names. I also improved the way zettels are edited by using the `json.Path` entry using plenary's path lib for normalisation.