### PR TITLE
Note home-manager installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ Plug 'nvim-lua/plenary.nvim'
 Plug 'nvim-telescope/telescope.nvim'
 ```
 
+[home-manager](https://github.com/nix-community/home-manager):
+
+```nix
+{
+  programs.neovim = {
+    enable = true;
+    plugins = with pkgs.vimPlugins; [
+      neuron-nvim
+      # ...
+    ];
+  };
+  # ...
+}
+```
+
 ## Usage
 
 You must run the setup function to be able to use this plugins. The setup function takes your config and merges it with the default config. Any key not specified will be a default. In your [init.lua](https://github.com/neovim/neovim/issues/7895), run


### PR DESCRIPTION
Hi oberblastermeister-

Great work on the plugin! I took the liberty of opening NixOS/nixpkgs#140404 to get you published in `nixpkgs.vimPlugins` (I'm a home-manager user myself [and it looks like you might be too], so this was the easiest way to get this into my config). I just checked, and it looks like hydra finished doing what it needed to do, so [we're live](https://search.nixos.org/packages?channel=unstable&show=vimPlugins.neuron-nvim&from=0&size=50&sort=relevance&type=packages&query=neuron-nvim)!

Thanks for your effort and consideration.