### PR TITLE
Update telescope actions to new action.state

### DIFF
--- a/lua/neuron/telescope/actions.lua
+++ b/lua/neuron/telescope/actions.lua
@@ -3,6 +3,7 @@ local config = require("neuron/config")
 local cmd = require("neuron/cmd")
 local utils = require("neuron/utils")
 local actions = require("telescope.actions")
+local actions_state = require("telescope.actions.state")
 
 local M = {}
 
@@ -10,7 +11,7 @@ function M.insert_maker(key)
   return function(prompt_bufnr)
     actions.close(prompt_bufnr)
 
-    local entry = actions.get_selected_entry()
+    local entry = actions_state.get_selected_entry()
     if key == "id" then
       api.nvim_put({"[[" .. entry[key] .. "]]"}, "c", true, true)
     end
@@ -23,11 +24,11 @@ end
 function M.edit_or_insert(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  local entry = actions.get_selected_entry()
+  local entry = actions_state.get_selected_entry()
   if entry ~= nil then
     vim.cmd("edit " .. entry.value)
   else
-    local current_line = actions.get_current_line() -- todo, need pr telescope for this
+    local current_line = actions_state.get_current_line() -- todo, need pr telescope for this
     cmd.new_and_callback(config.neuron_dir, function(data)
       vim.cmd("edit " .. data)
       utils.start_insert_header()
@@ -40,14 +41,14 @@ end
 function M.insert(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  local entry = actions.get_selected_entry()
+  local entry = actions_state.get_selected_entry()
   api.nvim_put({entry.id}, "c", true, true)
 end
 
 function M.new(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  vim.cmd("edit " .. actions.get_current_line() .. ".md")
+  vim.cmd("edit " .. actions_state.get_current_line() .. ".md")
 end
 
 return M


### PR DESCRIPTION
The newest version of telescope has deprecated the `actions.get_selected_entry()` and `actions.get_current_line()` for the equivalent versions in the `actions.state` namespace. This patch will bring the calls up to date.