### PR TITLE
Fix fake output on std_error

### DIFF
--- a/lua/neuron/cmd.lua
+++ b/lua/neuron/cmd.lua
@@ -85,7 +85,7 @@ function M.new_edit(neuron_dir)
     command = "neuron",
     args = {"new"},
     cwd = neuron_dir,
-    -- on_stderr = utils.on_stderr_factory("neuron new"),
+    on_stderr = utils.on_stderr_factory("neuron new"),
     interactive = false,
     on_exit = vim.schedule_wrap(
       function(job, return_val)

--- a/lua/neuron/utils.lua
+++ b/lua/neuron/utils.lua
@@ -23,11 +23,26 @@ function M.path_from_id(id, neuron_dir, callback)
   }:start()
 end
 
+local fake_errors = {
+  [[%s*Plugins enabled:]],
+  [[%s*Loading directory tree]],
+  [[%s*Building graph]]
+}
+
+function M.is_an_error(data)
+  for i=1,#fake_errors do
+    if data:match(fake_errors[i]) then
+      return false
+    end
+  end
+  return true
+end
+
 function M.on_stderr_factory(name)
   return vim.schedule_wrap(
     function(error, data)
       assert(not error, error)
-      if data ~= nil then
+      if data ~= nil and M.is_an_error(data) then
         vim.cmd(string.format("echoerr 'An error occured from running %s: %s'", name, data))
       end
     end


### PR DESCRIPTION
This should filter out the "fake" errors that neuron prints that are actually debug/info logs. I also re-enabled the error logging in the one place it had been disabled. I tried to think of a more generic way to filter them (maybe check for color?) but a map of fake errors was the best I could come up with.

Fixes #44 which was related to this. I think the error logging had been disabled in `new_edit` but not in `new_and_callback`. So, if you tried to make a new zettel by using the `find_zettels` command, you would see errors even though everything worked properly.