### PR TITLE
fix: correctly contstruct path for opening zettels in nested folders

### DIFF
--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -1,4 +1,5 @@
 local Job = require("plenary/job")
+local Path = require("plenary/path")
 local uv = vim.loop
 local api = vim.api
 local utils = require("neuron/utils")
@@ -65,7 +66,7 @@ function M.enter_link()
 
   cmd.query_id(id, config.neuron_dir, function(json)
     if type(json) ~= "userdata" then
-      vim.cmd(string.format("edit %s/%s.md", config.neuron_dir, json.ID))
+      vim.cmd(string.format("edit %s", Path:new(config.neuron_dir, json.Path):absolute()))
     end
   end)
 end


### PR DESCRIPTION
At the moment, only zettels at root level are handled correctly. If there any zettels nested in additional folders (for
example, I have `books` for bibliograph) - those can not be opened correctly. Note that `neuron` itself does handle
that - you can still see virtual text with titles for such zettels.

Use `plenary`'s path to not have to deal with pathing logic.