### PR TITLE
Clear all virtual titles before setting new ones

### DIFF
--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -159,7 +159,7 @@ local function setup_autocmds()
   end
   if config.virtual_titles == true then
     vim.cmd(string.format(
-                "au BufRead %s lua require'neuron'.add_all_virtual_titles()",
+                "au BufRead %s lua require'neuron'.update_virtual_titles()",
                 pathpattern))
     vim.cmd(string.format(
                 "au BufRead %s lua require'neuron'.attach_buffer_fast()",


### PR DESCRIPTION
Otherwise, if buffer is re-read for whatever reason, new set of duplicated titles is displayed. The easiest way to trigger this is to do a `:e` in a zettel.