### PR TITLE
Add a function to open a random Zettel

### DIFF
--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -245,4 +245,12 @@ function M.goto_index()
   vim.cmd(string.format("edit %s/index.md", config.neuron_dir))
 end
 
+---opens random zettel
+function M.open_random()
+  cmd.query({}, config.neuron_dir, function(json)
+    local random_zettel = json[math.random(#json)]
+    vim.cmd(string.format("edit %s", Path:new(config.neuron_dir, random_zettel.Path):absolute()))
+  end)
+end
+
 return M


### PR DESCRIPTION
Adds a function to open a random zettel. I occasionally find this useful to explore my Zettelkasten.

I haven't mapped any keys — but happy to add `gzr` (that I use in my config) if that's acceptable.
