### PR TITLE
Update to latest neovim / telescope API

### DIFF
--- a/lua/neuron.lua
+++ b/lua/neuron.lua
@@ -74,12 +74,14 @@ function M.enter_link()
 end
 
 function M.add_all_virtual_titles(buf)
+  buf = buf or 0
   for ln, line in ipairs(api.nvim_buf_get_lines(buf, 0, -1, true)) do
     M.add_virtual_title_current_line(buf, ln, line)
   end
 end
 
 function M.add_virtual_title_current_line(buf, ln, line)
+  buf = buf or 0
   if line ~= nil or line ~= "" then
     local start_col, end_col = utils.find_link(line)
     local id = utils.match_link(line)
@@ -114,6 +116,7 @@ function M.add_virtual_title_current_line(buf, ln, line)
 end
 
 function M.update_virtual_titles(buf)
+  buf = buf or 0
   api.nvim_buf_clear_namespace(buf, ns, 0, -1)
   M.add_all_virtual_titles()
 end

--- a/lua/neuron/telescope/actions.lua
+++ b/lua/neuron/telescope/actions.lua
@@ -3,6 +3,7 @@ local neuron = require("neuron")
 local cmd = require("neuron/cmd")
 local utils = require("neuron/utils")
 local actions = require('telescope.actions')
+local action_state = require('telescope.actions.state')
 
 local M = {}
 
@@ -10,7 +11,7 @@ function M.insert_maker(key)
   return function(prompt_bufnr)
     actions.close(prompt_bufnr)
 
-    local entry = actions.get_selected_entry()
+    local entry = action_state.get_selected_entry()
     api.nvim_put({entry[key]}, "c", true, true)
   end
 end
@@ -18,11 +19,11 @@ end
 function M.edit_or_insert(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  local entry = actions.get_selected_entry()
+  local entry = action_state.get_selected_entry()
   if entry ~= nil then
     vim.cmd("edit " .. entry.value)
   else
-    local current_line = actions.get_current_line() -- todo, need pr telescope for this
+    local current_line = action_state.get_current_line() -- todo, need pr telescope for this
     cmd.new_and_callback(neuron.config.neuron_dir, function(data)
       vim.cmd("edit " .. data)
       utils.start_insert_header()
@@ -35,14 +36,14 @@ end
 function M.insert(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  local entry = actions.get_selected_entry()
+  local entry = action_state.get_selected_entry()
   api.nvim_put({entry.id}, "c", true, true)
 end
 
 function M.new(prompt_bufnr)
   actions.close(prompt_bufnr)
 
-  vim.cmd("edit " .. actions.get_current_line() .. ".md")
+  vim.cmd("edit " .. action_state.get_current_line() .. ".md")
 end
 
 return M


### PR DESCRIPTION
Those are basic fixes for using neuron.nvim on the latest neovim builds (tested on 30c9c8815 from 2022-02-21), where passing nil as a buffer number is no longer allowed. I assume that the existence of the `buf` argument was intended for later use, but it actually could be totally unnecessary to keep.

Telescope also had changes in its internal APIs, where some utility functions are now in a separate module.